### PR TITLE
Add class type header to description panel.

### DIFF
--- a/src/app/input_manager.ts
+++ b/src/app/input_manager.ts
@@ -551,6 +551,8 @@ function getDescriptionForCharacter(character: Character): string[] {
 function getDescriptionForClass(characterClassType: ClassType): string[] {
     const characterClass = getCharacterClassForType(characterClassType);
     return [
+        `<b>${characterClassType}</b>`,
+        ``,
         `HP: ${characterClass.maxHealth}`,
         `Moves: ${characterClass.maxMovesPerTurn}`,
         `Sight: ${characterClass.maxSight}`,

--- a/src/app/input_manager.ts
+++ b/src/app/input_manager.ts
@@ -551,7 +551,7 @@ function getDescriptionForCharacter(character: Character): string[] {
 function getDescriptionForClass(characterClassType: ClassType): string[] {
     const characterClass = getCharacterClassForType(characterClassType);
     return [
-        `<b>${characterClassType}</b>`,
+        `${characterClassType}`,
         ``,
         `HP: ${characterClass.maxHealth}`,
         `Moves: ${characterClass.maxMovesPerTurn}`,


### PR DESCRIPTION
When in game, I forget the name of the unit that I'm moving. This request adds the name (Sniper, Demolition, etc.) to the top of the information panel.

Note: this change is untested (see this [issue](https://github.com/jstimes/SnagTheFlag/issues/1) for more context); the text should work, but I'm not sure if the HTML tag will parse.